### PR TITLE
Updated hash to match "Bumped crosstool-NG to v14.2.0_20241119"

### DIFF
--- a/esp-rs/riscv32-gcc.nix
+++ b/esp-rs/riscv32-gcc.nix
@@ -10,7 +10,7 @@ pkgs.stdenv.mkDerivation rec {
 
     src = pkgs.fetchzip {
             url = "https://github.com/espressif/crosstool-NG/releases/download/esp-${version}/riscv32-esp-elf-${version}-${archname}.tar.xz";
-            hash = "sha256-xSAtR0dnEW8xW/93eO4t9YgXREqo/R4PreXnalGQusM=";
+            hash = "sha256-67O34FYUnVG2nfkfQj2yH874qDSYx4F/16xxPi0kNbY=";
           };
 
     outputs = [ "out" ];

--- a/esp-rs/xtensa-gcc.nix
+++ b/esp-rs/xtensa-gcc.nix
@@ -10,7 +10,7 @@ pkgs.stdenv.mkDerivation rec {
 
     src = pkgs.fetchzip {
             url = "https://github.com/espressif/crosstool-NG/releases/download/esp-${version}/xtensa-esp-elf-${version}-${archname}.tar.xz";
-            hash = "sha256-uZ8md2PJQhIsJAHO7hK9+Hn8mPI/erhFpW22w/fS3+g=";
+            hash = "sha256-pX2KCnUoGZtgqFmZEuNRJxDMQgqYYPRpswL3f3T0nWE=";
           };
 
     outputs = [ "out" ];


### PR DESCRIPTION
Hi.
It's just small change. 
I got a hash mismatch because of the last update.
