### PR TITLE
export esp-rs as a package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,12 @@
       system: let
         pkgs = import nixpkgs {inherit system;};
         shell = pkgs.callPackage ./shell.nix {};
+        esp-rs-src = pkgs.lib.sources.cleanSource ./.;
       in {
         package = rec {
           inherit shell;
           default = shell;
+          esp-rs = pkgs.callPackage "${esp-rs-src}/esp-rs/default.nix" {};
         };
         devShells.default = shell;
       }


### PR DESCRIPTION
 why: make it easier to use this flake as input for other flake