### PR TITLE
native rust-analyzer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,21 +4,24 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
-  outputs = {
-    nixpkgs,
-    flake-utils,
-    ...
-  }:
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
     flake-utils.lib.eachDefaultSystem (
-      system: let
-        pkgs = import nixpkgs {inherit system;};
-        shell = pkgs.callPackage ./shell.nix {};
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        shell = pkgs.callPackage ./shell.nix { };
         esp-rs-src = pkgs.lib.sources.cleanSource ./.;
-      in {
+      in
+      {
         package = rec {
           inherit shell;
           default = shell;
-          esp-rs = pkgs.callPackage "${esp-rs-src}/esp-rs/default.nix" {};
+          esp-rs = pkgs.callPackage "${esp-rs-src}/esp-rs/default.nix" { };
         };
         devShells.default = shell;
       }

--- a/shell.nix
+++ b/shell.nix
@@ -1,44 +1,46 @@
-{ pkgs ? import <nixpkgs> {}}:
-let 
-    # Uses this folder as the source for esp-rs-nix (in-repo nix-shell)
-    esp-rs-src = pkgs.lib.sources.cleanSource ./.;
+{
+  pkgs ? import <nixpkgs> { },
+}:
+let
+  # Uses this folder as the source for esp-rs-nix (in-repo nix-shell)
+  esp-rs-src = pkgs.lib.sources.cleanSource ./.;
 
-    # Examples for out-of-repo nix-shell usage below.
-    #
-    # # Use the latest release of esp-rs-nix
-    # esp-rs-src = builtins.fetchTarball "https://github.com/leighleighleigh/esp-rs-nix/archive/master.tar.gz";
-    #
-    # # Use a pinned release of esp-rs-nix, at commit '0c3fa7245d38019e60c4ae56b2e98465c1b8a5dc'
-    # esp-rs-src = pkgs.fetchFromGitHub {
-    #   owner = "leighleighleigh";
-    #   repo = "esp-rs-nix";
-    #   rev = "0c3fa7245d38019e60c4ae56b2e98465c1b8a5dc";
-    #   hash = "sha256-b5kb6gxqutHySWEoweNfKbZw1r7DkwqRC39RWsyFSLU=";
-    # };
-    
-    # Call the package from wherever the source was obtained
-    esp-rs = pkgs.callPackage "${esp-rs-src}/esp-rs/default.nix" {};
+  # Examples for out-of-repo nix-shell usage below.
+  #
+  # # Use the latest release of esp-rs-nix
+  # esp-rs-src = builtins.fetchTarball "https://github.com/leighleighleigh/esp-rs-nix/archive/master.tar.gz";
+  #
+  # # Use a pinned release of esp-rs-nix, at commit '0c3fa7245d38019e60c4ae56b2e98465c1b8a5dc'
+  # esp-rs-src = pkgs.fetchFromGitHub {
+  #   owner = "leighleighleigh";
+  #   repo = "esp-rs-nix";
+  #   rev = "0c3fa7245d38019e60c4ae56b2e98465c1b8a5dc";
+  #   hash = "sha256-b5kb6gxqutHySWEoweNfKbZw1r7DkwqRC39RWsyFSLU=";
+  # };
+
+  # Call the package from wherever the source was obtained
+  esp-rs = pkgs.callPackage "${esp-rs-src}/esp-rs/default.nix" { };
 in
 pkgs.mkShell rec {
-    name = "esp-rs-nix";
-    
-    # You may wish to change these build inputs for your application
-    buildInputs = [
-        esp-rs
-        pkgs.rustup
-        pkgs.espflash
-        pkgs.rust-analyzer
-        pkgs.pkg-config
-        pkgs.stdenv.cc
-        pkgs.systemdMinimal
-    ];
+  name = "esp-rs-nix";
 
-    shellHook = ''
+  # You may wish to change these build inputs for your application
+  buildInputs = [
+    esp-rs
+    pkgs.rust-analyzer
+    pkgs.rustup
+    pkgs.espflash
+    pkgs.pkg-config
+    pkgs.stdenv.cc
+    pkgs.systemdMinimal
+  ];
+
+  shellHook = ''
     # Add a prefix 'esp-rs' to the shell prompt
     export PS1="(esp-rs)$PS1"
 
     # This variable is important - it tells rustup where to find the esp toolchain,
     # without needing to copy it into your local ~/.rustup/ folder.
     export RUSTUP_TOOLCHAIN=${esp-rs}
-    '';
+  '';
 }


### PR DESCRIPTION
Both `rustup` and `rust-analyzer` pkgs provide a `rust-analyzer` binary file.

Currently `rustup` is before `rust-analyzer` in the pkgs list of `shell.nix`, so it end up sooner in the PATH and the `rust-analyzer` bin from `rustup` has priority over the one from `rust-analyzer`.

This PR inverse that order, in order to use the `rust-analyzer` bin from `rust-analyzer` pkgs.

Also a lsp fmt has been done.